### PR TITLE
Specify Version for tk-framework-simple References

### DIFF
--- a/env/asset_step.yml
+++ b/env/asset_step.yml
@@ -37,7 +37,7 @@ engines:
           Photoshop Image: [texture_node]
           Rendered Image: [texture_node]
           UDIM Image: [udim_texture_node]
-        actions_hook: "{tk-framework-simple}/maya/loader_actions_abc.py"
+        actions_hook: "{tk-framework-simple_v0.x.x}/maya/loader_actions_abc.py"
         download_thumbnails: true
         entities:
         - caption: Assets
@@ -68,10 +68,10 @@ engines:
         hook_copy_file: default
         hook_post_publish: default
         hook_primary_pre_publish: default
-        hook_primary_publish: "{tk-framework-simple}/maya/primary_publish.py"
-        hook_scan_scene: "{tk-framework-simple}/maya/scan_scene_shader_networks.py"
-        hook_secondary_pre_publish: "{tk-framework-simple}/maya/secondary_pre_publish.py"
-        hook_secondary_publish: "{tk-framework-simple}/maya/secondary_publish.py"
+        hook_primary_publish: "{tk-framework-simple_v0.x.x}/maya/primary_publish.py"
+        hook_scan_scene: "{tk-framework-simple_v0.x.x}/maya/scan_scene_shader_networks.py"
+        hook_secondary_pre_publish: "{tk-framework-simple_v0.x.x}/maya/secondary_pre_publish.py"
+        hook_secondary_publish: "{tk-framework-simple_v0.x.x}/maya/secondary_publish.py"
         hook_thumbnail: default
         location: {name: tk-multi-publish, type: app_store, version: v0.6.2}
         primary_description: Publish and version up the current Maya scene
@@ -269,7 +269,7 @@ engines:
         height: 768
         location: {name: tk-nuke-quickdailies, type: app_store, version: v0.1.8}
         movie_template: asset_quicktime_quick
-        post_hooks: ["{tk-framework-simple}/snapshot_history_post_quickdaily.py"]
+        post_hooks: ["{tk-framework-simple_v0.x.x}/snapshot_history_post_quickdaily.py"]
         sg_version_name_template: nuke_quick_asset_version_name
         width: 1024
       tk-nuke-writenode:
@@ -411,6 +411,6 @@ frameworks:
     location: {name: tk-framework-widget, type: app_store, version: v0.1.19}
   tk-framework-widget_v0.1.22:
     location: {name: tk-framework-widget, type: app_store, version: v0.1.22}
-  tk-framework-simple:
+  tk-framework-simple_v0.x.x:
     location: {name: tk-framework-simple, type: git, path: "https://github.com/shotgunsoftware/tk-framework-simple.git", version: v0.0.1}
 

--- a/env/shot_step.yml
+++ b/env/shot_step.yml
@@ -39,7 +39,7 @@ engines:
           Alembic Cache: [reference, import]
           Camera: [reference, import]
           Maya Shader Network: [reference, import]
-        actions_hook: "{tk-framework-simple}/maya/loader_actions_abc.py"
+        actions_hook: "{tk-framework-simple_v0.x.x}/maya/loader_actions_abc.py"
         download_thumbnails: true
         entities:
         - caption: Assets
@@ -70,10 +70,10 @@ engines:
         hook_copy_file: default
         hook_post_publish: default
         hook_primary_pre_publish: default
-        hook_primary_publish: "{tk-framework-simple}/maya/primary_publish.py"
-        hook_scan_scene: "{tk-framework-simple}/maya/scan_scene.py"
-        hook_secondary_pre_publish: "{tk-framework-simple}/maya/secondary_pre_publish.py"
-        hook_secondary_publish: "{tk-framework-simple}/maya/secondary_publish.py"
+        hook_primary_publish: "{tk-framework-simple_v0.x.x}/maya/primary_publish.py"
+        hook_scan_scene: "{tk-framework-simple_v0.x.x}/maya/scan_scene.py"
+        hook_secondary_pre_publish: "{tk-framework-simple_v0.x.x}/maya/secondary_pre_publish.py"
+        hook_secondary_publish: "{tk-framework-simple_v0.x.x}/maya/secondary_publish.py"
         hook_thumbnail: default
         location: {name: tk-multi-publish, type: app_store, version: v0.6.10}
         primary_description: Publish and version up the current Maya scene
@@ -168,7 +168,7 @@ engines:
           Nuke Script: [script_import]
           Rendered Image: [read_node]
           Alembic Cache: [read_node]
-        actions_hook: "{tk-framework-simple}/nuke/loader_actions_abc.py"
+        actions_hook: "{tk-framework-simple_v0.x.x}/nuke/loader_actions_abc.py"
         download_thumbnails: true
         entities:
         - caption: Assets
@@ -267,7 +267,7 @@ engines:
         height: 768
         location: {name: tk-nuke-quickdailies, type: app_store, version: v0.1.8}
         movie_template: shot_quicktime_quick
-        post_hooks: ["{tk-framework-simple}/snapshot_history_post_quickdaily.py"]
+        post_hooks: ["{tk-framework-simple_v0.x.x}/snapshot_history_post_quickdaily.py"]
         sg_version_name_template: nuke_quick_shot_version_name
         width: 1024
       tk-nuke-writenode:
@@ -336,6 +336,6 @@ frameworks:
     location: {name: tk-framework-widget, type: app_store, version: v0.1.19}
   tk-framework-widget_v0.1.22:
     location: {name: tk-framework-widget, type: app_store, version: v0.1.22}
-  tk-framework-simple:
+  tk-framework-simple_v0.x.x:
     location: {name: tk-framework-simple, type: git, path: "https://github.com/shotgunsoftware/tk-framework-simple.git", version: v0.0.1}
 


### PR DESCRIPTION
Wasn't able to update without that change (said it couldn't find the version `tk-framework-simple`). Looking at the tank update code, it expects the format ~`.*_vx.x.x`, where `x` can be a number or left as `x` as a wildcard. This PR addresses this issue.

Note: it might be worth mentioning this little *gotcha* in the blog post about creating an internal framework.